### PR TITLE
Handle non‑language‑aware tables gracefully in `RecordSelection`

### DIFF
--- a/Classes/Domain/Repository/GenericRepository.php
+++ b/Classes/Domain/Repository/GenericRepository.php
@@ -86,14 +86,15 @@ class GenericRepository extends AbstractRepository
      * Find records on pages with language filtering.
      *
      * @param array<int> $pageUids
+     * @param string|null $languageField
      * @param array<int> $languages
      * @param array<class-string<QueryRestrictionInterface>|QueryRestrictionInterface> $restrictions
      * @return iterable<array<string, mixed>>
      */
     public function findRecordsOnPages(
         array $pageUids,
-        string $languageField,
-        array $languages,
+        ?string $languageField = null,
+        array $languages = [0, -1],
         array $restrictions = [],
     ): iterable {
         $queryBuilder = $this->createQueryBuilder();
@@ -106,12 +107,17 @@ class GenericRepository extends AbstractRepository
 
         // No empty storages
         $pageUids[] = -99;
+        $where = [
+            $queryBuilder->expr()->in('pid', $pageUids),
+        ];
+        if (!empty($languageField) && !empty($languages)) {
+            $where[] = $queryBuilder->expr()->in($languageField, $languages);
+        }
 
         $queryBuilder->select('*')
             ->from($this->getTableName())
             ->where(
-                $queryBuilder->expr()->in('pid', $pageUids),
-                $queryBuilder->expr()->in($languageField, $languages),
+                ...$where
             );
 
         return $queryBuilder->executeQuery()->iterateAssociative();

--- a/Classes/Traversing/RecordSelection.php
+++ b/Classes/Traversing/RecordSelection.php
@@ -6,7 +6,6 @@ namespace Lochmueller\Index\Traversing;
 
 use Lochmueller\Index\Database\Query\Restriction\NonContainerElementsRestrictionContainer;
 use Lochmueller\Index\Domain\Repository\GenericRepository;
-use TYPO3\CMS\Core\Context\Context;
 use TYPO3\CMS\Core\Context\LanguageAspect;
 use TYPO3\CMS\Core\Database\Query\Restriction\FrontendRestrictionContainer;
 use TYPO3\CMS\Core\Database\Query\Restriction\QueryRestrictionInterface;
@@ -16,7 +15,6 @@ use TYPO3\CMS\Core\Domain\Repository\PageRepository;
 use TYPO3\CMS\Core\Schema\Capability\LanguageAwareSchemaCapability;
 use TYPO3\CMS\Core\Schema\Capability\TcaSchemaCapability;
 use TYPO3\CMS\Core\Schema\TcaSchemaFactory;
-use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 class RecordSelection
 {
@@ -42,30 +40,31 @@ class RecordSelection
         ],
     ): iterable {
         $schema = $this->tcaSchemaFactory->get($table);
-        /** @var LanguageAwareSchemaCapability $languageCapability */
-        $languageCapability = $schema->getCapability(TcaSchemaCapability::Language);
-
-        $languages = [
+        if (!$schema->isLanguageAware()) {
+            $languageField = null;
+        } else {
+            /** @var LanguageAwareSchemaCapability $languageCapability */
+            $languageCapability = $schema->getCapability(TcaSchemaCapability::Language);
+            $languageField = $languageCapability->getLanguageField()->getName();
+        }
+        $languages = array_unique([
             0,
             -1,
             $languageUid,
-        ];
+        ]);
 
         $rows = $this->genericRepository
             ->setTableName($table)
             ->findRecordsOnPages(
                 $pageUids,
-                $languageCapability->getLanguageField()->getName(),
+                $languageField,
                 $languages,
                 $restrictions,
             );
 
-        /** @var PageRepository $pageRepository */
-        $pageRepository = GeneralUtility::makeInstance(PageRepository::class, GeneralUtility::makeInstance(Context::class));
-
         foreach ($rows as $row) {
             if ($languageUid) {
-                $overlay = $pageRepository->getLanguageOverlay($table, $row, new LanguageAspect($languageUid, $languageUid));
+                $overlay = $this->pageRepository->getLanguageOverlay($table, $row, new LanguageAspect($languageUid, $languageUid));
                 if ($overlay !== null) {
                     $record = $this->mapRecord($table, $overlay);
                     /** @var \TYPO3\CMS\Core\Domain\Record\LanguageInfo $langInfo */


### PR DESCRIPTION
Fixes a fatal error when `RecordSelection::findRecordsOnPage()` is called with a table that does not have TCA language capabilities
Resolves: #6