### PR TITLE
fix: no_search not respected in frontend and http indexer

### DIFF
--- a/Classes/Traversing/PageTraversing.php
+++ b/Classes/Traversing/PageTraversing.php
@@ -55,6 +55,10 @@ class PageTraversing
                     continue;
                 }
 
+                if ($configuration->skipNoSearchPages && ($row['no_search'] ?? false)) {
+                    continue;
+                }
+
                 foreach ($extenderConfiguration as $item) {
                     $dropOriginalUri = isset($item['dropOriginalUri']) && $item['dropOriginalUri'];
                     if (!isset($item['limitToPages']) || (is_array($item['limitToPages']) && in_array($relevantPageUid, $item['limitToPages'], true))) {


### PR DESCRIPTION
this mr fixes this issue https://github.com/lochmueller/index/issues/8 

@lochmueller I have one question regarding the `DatabaseIndexer`: currently the `no_search` check happens in the message handler.

Wouldn't it make more sense to already check this in `PageTraversing::getFrontendInformation()` so that no message is created in the first place for pages that should not be indexed?

That would mean the queue only contains pages that are actually meant to be indexed, and the decision not to index would not be deferred to the handler.

In my MR, I already implemented it at that point as well. If that approach is okay, then we could remove the `no_search` check from `DatabaseIndexingHandler`, since it would already be handled earlier in the flow.

If you prefer that the decision should stay in the handler, I can adjust the MR accordingly.

Thanks for the nice extension!

Best regards