### PR TITLE
feat: dispatch delete message for no_search pages

### DIFF
--- a/Classes/Event/DeletePageEvent.php
+++ b/Classes/Event/DeletePageEvent.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lochmueller\Index\Event;
+
+use TYPO3\CMS\Core\Site\Entity\SiteInterface;
+
+final readonly class DeletePageEvent
+{
+    public function __construct(
+        public SiteInterface $site,
+        public string        $uri
+    ) {}
+}

--- a/Classes/Hooks/DataHandlerUpdateHook.php
+++ b/Classes/Hooks/DataHandlerUpdateHook.php
@@ -4,11 +4,16 @@ declare(strict_types=1);
 
 namespace Lochmueller\Index\Hooks;
 
+use HDNET\Calendarize\Domain\Model\Index;
 use Lochmueller\Index\Configuration\Configuration;
 use Lochmueller\Index\Configuration\ConfigurationLoader;
 use Lochmueller\Index\Domain\Repository\GenericRepository;
 use Lochmueller\Index\Enums\IndexPartialTrigger;
+use Lochmueller\Index\Event\DeletePageEvent;
 use Lochmueller\Index\Indexing\ActiveIndexing;
+use Lochmueller\Index\Queue\Bus;
+use Lochmueller\Index\Queue\Message\DeletePageMessage;
+use Lochmueller\Index\Service\DeletePageService;
 use Symfony\Component\DependencyInjection\Attribute\Autoconfigure;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use TYPO3\CMS\Core\Cache\Frontend\FrontendInterface;
@@ -19,11 +24,12 @@ use TYPO3\CMS\Core\Utility\MathUtility;
 class DataHandlerUpdateHook
 {
     public function __construct(
-        protected ConfigurationLoader $configurationLoader,
-        protected ActiveIndexing $activeIndexing,
+        protected ConfigurationLoader      $configurationLoader,
+        protected ActiveIndexing           $activeIndexing,
         #[Autowire(service: 'cache.runtime')]
         private readonly FrontendInterface $cache,
         private readonly GenericRepository $genericRepository,
+        private readonly Bus $bus,
     ) {}
 
     /**
@@ -40,6 +46,11 @@ class DataHandlerUpdateHook
             $record = $this->genericRepository->setTableName($table)->findByUid((int) $id);
             if ($record) {
                 $field = $table === 'pages' ? 'uid' : 'pid';
+                if (isset($record['no_search']) && $record['no_search']) {
+                    $this->triggerDocumentDeleteForPage((int)$record['uid'], (int)$record['sys_language_uid'], IndexPartialTrigger::Datamap);
+                    return;
+                }
+
                 $this->triggerPartialIndexProcessForPage((int) $record[$field], IndexPartialTrigger::Datamap);
             }
         }
@@ -74,24 +85,49 @@ class DataHandlerUpdateHook
         }
     }
 
-    protected function triggerPartialIndexProcessForPage(int $pageId, IndexPartialTrigger $trigger): void
+    protected function triggerDocumentDeleteForPage(int $pageId, int $languageId, IndexPartialTrigger $trigger): void
     {
-        $alreadyTriggered = (array) $this->cache->get('index-already-triggered');
-        $configuration = $this->configurationLoader->loadByPageTraversing($pageId);
-        if (!$configuration instanceof Configuration || !in_array($trigger->value, $configuration->partialIndexing, true)) {
-            return;
-        }
-
-        if (in_array($pageId, $alreadyTriggered, true)) {
-            return;
-        }
-        $alreadyTriggered[] = $pageId;
-        $this->cache->set('index-already-triggered', $alreadyTriggered);
         if ($pageId === 0) {
             return;
         }
 
+        if (!($configuration = $this->getTriggerableConfiguration($pageId, $trigger)) || !$configuration->skipNoSearchPages) {
+            return;
+        }
+
+        $this->bus->dispatch(new DeletePageMessage($pageId, $languageId));
+    }
+
+    protected function triggerPartialIndexProcessForPage(int $pageId, IndexPartialTrigger $trigger): void
+    {
+        if ($pageId === 0) {
+            return;
+        }
+
+        if (!$configuration = $this->getTriggerableConfiguration($pageId, $trigger)) {
+            return;
+        }
+
         $this->activeIndexing->fillQueue($configuration->modifyForPartialIndexing($pageId), true);
+    }
+
+    private function getTriggerableConfiguration(int $pageId, IndexPartialTrigger $trigger): ?Configuration
+    {
+        $alreadyTriggered = (array) $this->cache->get('index-already-triggered');
+        $configuration = $this->configurationLoader->loadByPageTraversing($pageId);
+
+        if (!$configuration instanceof Configuration || !in_array($trigger->value, $configuration->partialIndexing, true)) {
+            return null;
+        }
+
+        if (in_array($pageId, $alreadyTriggered, true)) {
+            return null;
+        }
+
+        $alreadyTriggered[] = $pageId;
+        $this->cache->set('index-already-triggered', $alreadyTriggered);
+
+        return $configuration;
     }
 
 }

--- a/Classes/Queue/Handler/DeletePageProcessHandler.php
+++ b/Classes/Queue/Handler/DeletePageProcessHandler.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lochmueller\Index\Queue\Handler;
+
+use Lochmueller\Index\Event\DeletePageEvent;
+use Lochmueller\Index\Queue\Message\DeletePageMessage;
+use Psr\EventDispatcher\EventDispatcherInterface;
+use Psr\Log\LoggerAwareInterface;
+use Psr\Log\LoggerAwareTrait;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+use TYPO3\CMS\Core\Exception\SiteNotFoundException;
+use TYPO3\CMS\Core\Routing\InvalidRouteArgumentsException;
+use TYPO3\CMS\Core\Site\SiteFinder;
+
+final class DeletePageProcessHandler implements LoggerAwareInterface
+{
+    use LoggerAwareTrait;
+
+    public function __construct(
+        protected SiteFinder $siteFinder,
+        private readonly EventDispatcherInterface $eventDispatcher,
+    )
+    {
+    }
+
+    #[AsMessageHandler]
+    public function __invoke(DeletePageMessage $message): void
+    {
+        try {
+            $site = $this->siteFinder->getSiteByPageId($message->pageUid);
+            $language = $site->getLanguageById($message->languageId);
+
+            $uri = (string)$site->getRouter()->generateUri($message->pageUid, ['_language' => $language]);
+
+            $this->eventDispatcher->dispatch(new DeletePageEvent($site, $uri));
+        } catch (SiteNotFoundException|\InvalidArgumentException|InvalidRouteArgumentsException $exception) {
+            $this->logger?->error($exception->getMessage(), ['exception' => $exception]);
+        } catch (\Exception $exception) {
+            $d=1;
+        }
+    }
+}

--- a/Classes/Queue/Message/DeletePageMessage.php
+++ b/Classes/Queue/Message/DeletePageMessage.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lochmueller\Index\Queue\Message;
+
+final class DeletePageMessage
+{
+    public function __construct(
+        public int $pageUid,
+        public int $languageId
+    ) {}
+
+}

--- a/Tests/Unit/Hooks/DataHandlerUpdateHookTest.php
+++ b/Tests/Unit/Hooks/DataHandlerUpdateHookTest.php
@@ -11,6 +11,7 @@ use Lochmueller\Index\Enums\IndexPartialTrigger;
 use Lochmueller\Index\Enums\IndexTechnology;
 use Lochmueller\Index\Hooks\DataHandlerUpdateHook;
 use Lochmueller\Index\Indexing\ActiveIndexing;
+use Lochmueller\Index\Queue\Bus;
 use Lochmueller\Index\Tests\Unit\AbstractTest;
 use TYPO3\CMS\Core\Cache\Frontend\FrontendInterface;
 use TYPO3\CMS\Core\DataHandling\DataHandler;
@@ -52,6 +53,7 @@ class DataHandlerUpdateHookTest extends AbstractTest
         $configurationLoaderStub = $this->createStub(ConfigurationLoader::class);
         $configurationLoaderStub->method('loadByPageTraversing')->willReturn($configuration);
 
+        $busStub = $this->createStub(Bus::class);
         $activeIndexingMock = $this->createMock(ActiveIndexing::class);
         $activeIndexingMock
             ->expects(self::once())
@@ -63,6 +65,7 @@ class DataHandlerUpdateHookTest extends AbstractTest
             $activeIndexingMock,
             $cacheStub,
             $this->createGenericRepositoryStub(),
+            bus: $busStub,
         );
         $subject->clearCacheCmd(['pageIdArray' => [123]], $this->createStub(DataHandler::class));
     }
@@ -80,11 +83,13 @@ class DataHandlerUpdateHookTest extends AbstractTest
         $activeIndexingMock = $this->createMock(ActiveIndexing::class);
         $activeIndexingMock->expects(self::never())->method('fillQueue');
 
+        $busStub = $this->createStub(Bus::class);
         $subject = new DataHandlerUpdateHook(
             $configurationLoaderStub,
             $activeIndexingMock,
             $cacheStub,
             $this->createGenericRepositoryStub(),
+            $busStub
         );
         $subject->clearCacheCmd(['pageIdArray' => [123]], $this->createStub(DataHandler::class));
     }
@@ -100,11 +105,13 @@ class DataHandlerUpdateHookTest extends AbstractTest
         $activeIndexingMock = $this->createMock(ActiveIndexing::class);
         $activeIndexingMock->expects(self::never())->method('fillQueue');
 
+        $busStub = $this->createStub(Bus::class);
         $subject = new DataHandlerUpdateHook(
             $configurationLoaderStub,
             $activeIndexingMock,
             $cacheStub,
             $this->createGenericRepositoryStub(),
+            $busStub
         );
         $subject->clearCacheCmd(['pageIdArray' => [123]], $this->createStub(DataHandler::class));
     }
@@ -122,11 +129,14 @@ class DataHandlerUpdateHookTest extends AbstractTest
         $activeIndexingMock = $this->createMock(ActiveIndexing::class);
         $activeIndexingMock->expects(self::never())->method('fillQueue');
 
+        $busStub = $this->createStub(Bus::class);
+
         $subject = new DataHandlerUpdateHook(
             $configurationLoaderStub,
             $activeIndexingMock,
             $cacheStub,
             $this->createGenericRepositoryStub(),
+            $busStub
         );
         $subject->clearCacheCmd(['pageIdArray' => [123]], $this->createStub(DataHandler::class));
     }
@@ -143,12 +153,14 @@ class DataHandlerUpdateHookTest extends AbstractTest
 
         $activeIndexingMock = $this->createMock(ActiveIndexing::class);
         $activeIndexingMock->expects(self::never())->method('fillQueue');
+        $busStub = $this->createStub(Bus::class);
 
         $subject = new DataHandlerUpdateHook(
             $configurationLoaderStub,
             $activeIndexingMock,
             $cacheStub,
             $this->createGenericRepositoryStub(),
+            $busStub
         );
         $subject->clearCacheCmd(['pageIdArray' => [0]], $this->createStub(DataHandler::class));
     }
@@ -165,12 +177,14 @@ class DataHandlerUpdateHookTest extends AbstractTest
 
         $activeIndexingMock = $this->createMock(ActiveIndexing::class);
         $activeIndexingMock->expects(self::exactly(2))->method('fillQueue');
+        $busStub = $this->createStub(Bus::class);
 
         $subject = new DataHandlerUpdateHook(
             $configurationLoaderStub,
             $activeIndexingMock,
             $cacheStub,
             $this->createGenericRepositoryStub(),
+            $busStub
         );
         $subject->clearCacheCmd(['pageIdArray' => [123, 456]], $this->createStub(DataHandler::class));
     }
@@ -183,11 +197,13 @@ class DataHandlerUpdateHookTest extends AbstractTest
         $activeIndexingMock = $this->createMock(ActiveIndexing::class);
         $activeIndexingMock->expects(self::never())->method('fillQueue');
 
+        $busStub = $this->createStub(Bus::class);
         $subject = new DataHandlerUpdateHook(
             $configurationLoaderMock,
             $activeIndexingMock,
             $this->createStub(FrontendInterface::class),
             $this->createGenericRepositoryStub(),
+            $busStub
         );
         $subject->clearCacheCmd(['pageIdArray' => []], $this->createStub(DataHandler::class));
     }
@@ -199,12 +215,14 @@ class DataHandlerUpdateHookTest extends AbstractTest
 
         $activeIndexingMock = $this->createMock(ActiveIndexing::class);
         $activeIndexingMock->expects(self::never())->method('fillQueue');
+        $busStub = $this->createStub(Bus::class);
 
         $subject = new DataHandlerUpdateHook(
             $configurationLoaderMock,
             $activeIndexingMock,
             $this->createStub(FrontendInterface::class),
             $this->createGenericRepositoryStub(),
+            $busStub
         );
         $subject->clearCacheCmd([], $this->createStub(DataHandler::class));
     }
@@ -229,11 +247,14 @@ class DataHandlerUpdateHookTest extends AbstractTest
             ->method('fillQueue')
             ->with(self::isInstanceOf(Configuration::class), true);
 
+        $busStub = $this->createStub(Bus::class);
+
         $subject = new DataHandlerUpdateHook(
             $configurationLoaderStub,
             $activeIndexingMock,
             $cacheStub,
             $genericRepositoryStub,
+            $busStub
         );
         $subject->processDatamap_afterDatabaseOperations(
             'update',
@@ -264,11 +285,14 @@ class DataHandlerUpdateHookTest extends AbstractTest
             ->method('fillQueue')
             ->with(self::isInstanceOf(Configuration::class), true);
 
+        $busStub = $this->createStub(Bus::class);
+
         $subject = new DataHandlerUpdateHook(
             $configurationLoaderStub,
             $activeIndexingMock,
             $cacheStub,
             $genericRepositoryStub,
+            $busStub
         );
         $subject->processDatamap_afterDatabaseOperations(
             'update',
@@ -287,11 +311,14 @@ class DataHandlerUpdateHookTest extends AbstractTest
         $genericRepositoryMock = $this->createMock(GenericRepository::class);
         $genericRepositoryMock->expects(self::never())->method('setTableName');
 
+        $busStub = $this->createStub(Bus::class);
+
         $subject = new DataHandlerUpdateHook(
             $this->createStub(ConfigurationLoader::class),
             $activeIndexingMock,
             $this->createStub(FrontendInterface::class),
             $genericRepositoryMock,
+            $busStub
         );
         $subject->processDatamap_afterDatabaseOperations(
             'new',
@@ -311,11 +338,14 @@ class DataHandlerUpdateHookTest extends AbstractTest
         $activeIndexingMock = $this->createMock(ActiveIndexing::class);
         $activeIndexingMock->expects(self::never())->method('fillQueue');
 
+        $busStub = $this->createStub(Bus::class);
+
         $subject = new DataHandlerUpdateHook(
             $this->createStub(ConfigurationLoader::class),
             $activeIndexingMock,
             $this->createStub(FrontendInterface::class),
             $genericRepositoryStub,
+            $busStub
         );
         $subject->processDatamap_afterDatabaseOperations(
             'update',
@@ -342,12 +372,14 @@ class DataHandlerUpdateHookTest extends AbstractTest
 
         $activeIndexingMock = $this->createMock(ActiveIndexing::class);
         $activeIndexingMock->expects(self::never())->method('fillQueue');
+        $busStub = $this->createStub(Bus::class);
 
         $subject = new DataHandlerUpdateHook(
             $configurationLoaderStub,
             $activeIndexingMock,
             $cacheStub,
             $genericRepositoryStub,
+            $busStub
         );
         $subject->processDatamap_afterDatabaseOperations(
             'update',
@@ -378,11 +410,14 @@ class DataHandlerUpdateHookTest extends AbstractTest
             ->method('fillQueue')
             ->with(self::isInstanceOf(Configuration::class), true);
 
+        $busStub = $this->createStub(Bus::class);
+
         $subject = new DataHandlerUpdateHook(
             $configurationLoaderStub,
             $activeIndexingMock,
             $cacheStub,
             $genericRepositoryStub,
+            $busStub
         );
         $subject->processCmdmap_postProcess(
             'move',
@@ -414,12 +449,15 @@ class DataHandlerUpdateHookTest extends AbstractTest
             ->expects(self::once())
             ->method('fillQueue')
             ->with(self::isInstanceOf(Configuration::class), true);
+        $busStub = $this->createStub(Bus::class);
+
 
         $subject = new DataHandlerUpdateHook(
             $configurationLoaderStub,
             $activeIndexingMock,
             $cacheStub,
             $genericRepositoryStub,
+            $busStub
         );
         $subject->processCmdmap_postProcess(
             'copy',
@@ -439,12 +477,14 @@ class DataHandlerUpdateHookTest extends AbstractTest
 
         $genericRepositoryMock = $this->createMock(GenericRepository::class);
         $genericRepositoryMock->expects(self::never())->method('setTableName');
+        $busStub = $this->createStub(Bus::class);
 
         $subject = new DataHandlerUpdateHook(
             $this->createStub(ConfigurationLoader::class),
             $activeIndexingMock,
             $this->createStub(FrontendInterface::class),
             $genericRepositoryMock,
+            $busStub
         );
         $subject->processCmdmap_postProcess(
             'delete',
@@ -465,12 +505,14 @@ class DataHandlerUpdateHookTest extends AbstractTest
 
         $activeIndexingMock = $this->createMock(ActiveIndexing::class);
         $activeIndexingMock->expects(self::never())->method('fillQueue');
+        $busStub = $this->createStub(Bus::class);
 
         $subject = new DataHandlerUpdateHook(
             $this->createStub(ConfigurationLoader::class),
             $activeIndexingMock,
             $this->createStub(FrontendInterface::class),
             $genericRepositoryStub,
+            $busStub
         );
         $subject->processCmdmap_postProcess(
             'delete',
@@ -499,12 +541,14 @@ class DataHandlerUpdateHookTest extends AbstractTest
 
         $activeIndexingMock = $this->createMock(ActiveIndexing::class);
         $activeIndexingMock->expects(self::never())->method('fillQueue');
+        $busStub = $this->createStub(Bus::class);
 
         $subject = new DataHandlerUpdateHook(
             $configurationLoaderStub,
             $activeIndexingMock,
             $cacheStub,
             $genericRepositoryStub,
+            $busStub
         );
         $subject->processCmdmap_postProcess(
             'move',


### PR DESCRIPTION
This is part of a combined feature #12  implemented across `index` and `seal`.

When a page is updated in the backend and marked as `no_search`, the DataMap hook now dispatches a `DeletePageMessage`.

The message is handled by `DeletePageProcessHandler`, which emits `DeletePageEvent`.
Actual document deletion is handled in the `seal` repository.

MR in seal repo: https://github.com/lochmueller/seal/pull/12